### PR TITLE
chore: update gputypes to v0.2.0 (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-01-29
+
+### Changed
+
+- **Update gputypes to v0.2.0** for webgpu.h spec-compliant enum values
+
+[0.3.1]: https://github.com/gogpu/gpucontext/releases/tag/v0.3.1
+
 ## [0.3.0] - 2026-01-29
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,21 +4,27 @@
 
 `gpucontext` is the shared foundation for the [gogpu](https://github.com/gogpu) ecosystem, providing interfaces and utilities for GPU resource sharing without circular dependencies.
 
-## Current: v0.2.0
+## Current: v0.3.1
 
 **Status:** Released
 
+- Import gputypes v0.2.0 (webgpu.h spec-compliant enums)
 - DeviceProvider interface
 - EventSource interface (with IME support)
 - Registry[T] generic
-- WebGPU type definitions
+
+## Released
+
+### v0.3.0 (2026-01-29)
+- Import gputypes for unified WebGPU types
+
+### v0.2.0 (2026-01-27)
 - IME support for CJK input
 
-## Previous: v0.1.1
-
+### v0.1.1 (2026-01-27)
 - Initial release with DeviceProvider, EventSource, Registry
 
-## Planned: v0.3.0
+## Planned: v0.4.0
 
 **Focus:** Extended capabilities
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gogpu/gpucontext
 
 go 1.25
 
-require github.com/gogpu/gputypes v0.1.0
+require github.com/gogpu/gputypes v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gogpu/gputypes v0.1.0 h1:n8tAmV9qPZA5E7JBBbRfmT0k7NFfNHxUUPi5vqy3I2I=
-github.com/gogpu/gputypes v0.1.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
+github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=


### PR DESCRIPTION
## Summary
- Update gputypes dependency to v0.2.0

## Why
- gputypes v0.2.0 provides webgpu.h spec-compliant enum values
- Binary compatibility with wgpu-native and other WebGPU implementations

## Changes
- go.mod: gputypes v0.1.0 → v0.2.0
- CHANGELOG.md: Add v0.3.1 entry
- ROADMAP.md: Update current version

## Test plan
- [x] Build passes
- [x] No breaking API changes