### PR TITLE
feat: add Texture, TextureDrawer and Touch interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-01-30
+
+### Added
+
+- **Texture interfaces** for GPU texture sharing across packages
+  - `Texture` — minimal interface with Width/Height
+  - `TextureDrawer` — interface for drawing textures (DrawTexture, DrawTextureEx)
+  - `TextureCreator` — interface for creating textures from pixel data
+  - `TextureDrawOptions` — options for advanced texture rendering (position, scale, alpha, flip)
+
+- **Touch input support** for mobile and tablet applications
+  - `TouchID` — unique identifier for touch points
+  - `TouchPhase` — lifecycle stages (Began, Moved, Ended, Cancelled)
+  - `TouchPoint` — single touch contact with position, optional pressure/radius
+  - `TouchEvent` — complete touch event with Changed/All points, modifiers, timestamp
+  - `TouchEventSource` — interface for registering touch callbacks
+  - `NullTouchEventSource` — no-op implementation for non-touch platforms
+
+### Notes
+
+- Touch interfaces follow platform conventions (iOS, Android, W3C Touch Events)
+- Texture interfaces enable gg↔gogpu integration without circular dependencies
+- Both are **contracts only** — implementations in host applications
+
+[0.4.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.4.0
+
 ## [0.3.1] - 2026-01-29
 
 ### Changed

--- a/device_provider.go
+++ b/device_provider.go
@@ -1,5 +1,5 @@
 // Copyright 2026 The gogpu Authors
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: MIT
 
 package gpucontext
 

--- a/doc.go
+++ b/doc.go
@@ -4,8 +4,11 @@
 // projects to enable GPU resource sharing without circular dependencies:
 //
 //   - DeviceProvider: Interface for providing GPU device and queue
-//   - Registry[T]: Generic registry for backend implementations
-//   - Type aliases: Convenience re-exports from wgpu/types
+//   - EventSource: Interface for window/input events (keyboard, mouse)
+//   - TouchEventSource: Interface for touch input (multi-touch, gestures)
+//   - Texture: Minimal interface for GPU textures
+//   - TextureDrawer: Interface for drawing textures (2D rendering)
+//   - TextureCreator: Interface for creating textures from pixel data
 //
 // # Consumers
 //

--- a/events.go
+++ b/events.go
@@ -1,5 +1,5 @@
 // Copyright 2026 The gogpu Authors
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: MIT
 
 package gpucontext
 

--- a/events_test.go
+++ b/events_test.go
@@ -1,5 +1,5 @@
 // Copyright 2026 The gogpu Authors
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: MIT
 
 package gpucontext
 
@@ -28,11 +28,11 @@ func TestNullEventSource(t *testing.T) {
 
 func TestModifiers(t *testing.T) {
 	tests := []struct {
-		mods     Modifiers
-		shift    bool
-		control  bool
-		alt      bool
-		super    bool
+		mods    Modifiers
+		shift   bool
+		control bool
+		alt     bool
+		super   bool
 	}{
 		{0, false, false, false, false},
 		{ModShift, true, false, false, false},

--- a/texture.go
+++ b/texture.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gpucontext
+
+// Texture is the minimal interface for GPU textures.
+// This interface enables type-safe cross-package texture handling
+// without circular dependencies.
+//
+// Implementations:
+//   - gogpu.Texture implements Texture
+//
+// Design note: This interface intentionally contains only read-only
+// methods that are universally needed for texture operations.
+// Implementation-specific methods (like UpdateData) remain on
+// concrete types.
+type Texture interface {
+	// Width returns the texture width in pixels.
+	Width() int
+
+	// Height returns the texture height in pixels.
+	Height() int
+}
+
+// TextureDrawer provides texture drawing capabilities for 2D rendering.
+// This interface enables packages like ggcanvas to draw textures without
+// depending directly on gogpu, following the Dependency Inversion Principle.
+//
+// Implementations:
+//   - gogpu.Context implements TextureDrawer (via adapter)
+//
+// Example usage in ggcanvas:
+//
+//	func (c *Canvas) RenderTo(drawer gpucontext.TextureDrawer) error {
+//	    tex, _ := c.Flush()
+//	    return drawer.DrawTexture(tex, 0, 0)
+//	}
+type TextureDrawer interface {
+	// DrawTexture draws a texture at the specified position.
+	//
+	// Coordinate system:
+	//   - (0, 0) is the top-left corner
+	//   - Positive X goes right
+	//   - Positive Y goes down
+	//   - Coordinates are in pixels
+	//
+	// The texture must have been created by TextureCreator from this drawer.
+	DrawTexture(tex Texture, x, y float32) error
+
+	// TextureCreator returns the texture creator associated with this drawer.
+	// Use this to create textures that can be drawn by this drawer.
+	TextureCreator() TextureCreator
+}
+
+// TextureCreator provides texture creation from raw pixel data.
+// This interface enables packages to create GPU textures without
+// depending directly on specific GPU implementations.
+//
+// Implementations:
+//   - gogpu.Renderer implements TextureCreator (via adapter)
+//
+// Example usage:
+//
+//	creator := drawer.TextureCreator()
+//	tex, err := creator.NewTextureFromRGBA(800, 600, pixelData)
+//	if err != nil {
+//	    return err
+//	}
+//	drawer.DrawTexture(tex, 0, 0)
+type TextureCreator interface {
+	// NewTextureFromRGBA creates a texture from RGBA pixel data.
+	// The data must be width * height * 4 bytes (RGBA, 8 bits per channel).
+	//
+	// The returned Texture can be drawn using TextureDrawer.DrawTexture.
+	//
+	// Returns error if:
+	//   - Data size doesn't match width * height * 4
+	//   - GPU texture creation fails
+	NewTextureFromRGBA(width, height int, data []byte) (Texture, error)
+}

--- a/touch.go
+++ b/touch.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gpucontext
+
+import "time"
+
+// TouchID uniquely identifies a touch point within a touch session.
+// The ID remains constant from TouchBegan through TouchEnded/TouchCancelled.
+// IDs may be reused after a touch ends.
+//
+// Design note: Using int for compatibility with both int32 (Android) and int64 (iOS).
+// Matches Ebitengine pattern for familiarity.
+type TouchID int
+
+// TouchPhase represents the lifecycle stage of a touch point.
+// These phases align with platform conventions:
+//   - Android: ACTION_DOWN/MOVE/UP/CANCEL
+//   - iOS: touchesBegan/Moved/Ended/Cancelled
+//   - W3C: touchstart/move/end/cancel
+type TouchPhase uint8
+
+const (
+	// TouchBegan indicates first contact with the touch surface.
+	// Sent once per touch point at the start of interaction.
+	TouchBegan TouchPhase = iota
+
+	// TouchMoved indicates the touch point has moved.
+	// Sent multiple times during drag/pan gestures.
+	TouchMoved
+
+	// TouchEnded indicates the touch point was lifted normally.
+	// Sent once per touch point at the end of interaction.
+	TouchEnded
+
+	// TouchCancelled indicates the system interrupted the touch.
+	// This can happen when:
+	//   - The app loses focus
+	//   - A system gesture is recognized (e.g., swipe to home)
+	//   - The touch hardware reports an error
+	// Always handle cancellation to reset UI state properly.
+	TouchCancelled
+)
+
+// String returns the phase name for debugging.
+func (p TouchPhase) String() string {
+	switch p {
+	case TouchBegan:
+		return "Began"
+	case TouchMoved:
+		return "Moved"
+	case TouchEnded:
+		return "Ended"
+	case TouchCancelled:
+		return "Cancelled"
+	default:
+		return "Unknown"
+	}
+}
+
+// TouchPoint represents a single point of contact on a touch surface.
+//
+// Position coordinates are in logical pixels relative to the window's
+// content area. The coordinate system matches the graphics system:
+//   - Origin (0, 0) is at top-left
+//   - X increases rightward
+//   - Y increases downward
+//
+// Design decisions:
+//   - Using float64 for sub-pixel precision (matches mouse events in EventSource)
+//   - Pressure/Radius are pointers to indicate optional support
+//   - No coordinate transformation - that's the UI layer's responsibility
+type TouchPoint struct {
+	// ID uniquely identifies this touch point within the session.
+	// Track touches by ID, not by array index (indices can change).
+	ID TouchID
+
+	// X is the horizontal position in logical pixels.
+	X float64
+
+	// Y is the vertical position in logical pixels.
+	Y float64
+
+	// Pressure is the contact pressure, if supported by hardware.
+	// Range: 0.0 (no pressure) to 1.0 (maximum pressure).
+	// nil if pressure sensing is not available.
+	//
+	// Use case: Drawing apps, pressure-sensitive UI elements.
+	Pressure *float32
+
+	// Radius is the approximate contact radius in logical pixels.
+	// Represents a circular approximation of the contact area.
+	// nil if radius detection is not available.
+	//
+	// Use case: Distinguishing finger vs knuckle touches,
+	// accessibility features for users with larger contact areas.
+	Radius *float32
+}
+
+// TouchEvent represents a touch input event containing one or more touch points.
+//
+// Multi-touch handling:
+//   - TouchBegan: Changed contains new touches, All contains all active touches
+//   - TouchMoved: Changed contains moved touches, All contains all active touches
+//   - TouchEnded: Changed contains lifted touches, All contains remaining touches
+//   - TouchCancelled: Changed contains cancelled touches, All may be empty
+//
+// Example multi-touch pinch gesture processing:
+//
+//	func handleTouch(ev gpucontext.TouchEvent) {
+//	    if ev.Phase == gpucontext.TouchMoved && len(ev.All) == 2 {
+//	        // Calculate distance between two fingers for pinch
+//	        dx := ev.All[0].X - ev.All[1].X
+//	        dy := ev.All[0].Y - ev.All[1].Y
+//	        distance := math.Sqrt(dx*dx + dy*dy)
+//	        // Use distance for zoom...
+//	    }
+//	}
+type TouchEvent struct {
+	// Phase indicates the lifecycle stage of the touches in Changed.
+	Phase TouchPhase
+
+	// Changed contains the touch points that triggered this event.
+	// For TouchBegan: newly added touches
+	// For TouchMoved: touches that moved
+	// For TouchEnded: touches that were lifted
+	// For TouchCancelled: touches that were interrupted
+	Changed []TouchPoint
+
+	// All contains all currently active touch points.
+	// Useful for multi-touch gestures that need to track all contacts.
+	// For TouchEnded/TouchCancelled, this excludes the Changed touches.
+	All []TouchPoint
+
+	// Modifiers contains keyboard modifier state at the time of the event.
+	// Useful for modifier+touch combinations (e.g., Ctrl+drag for zoom).
+	Modifiers Modifiers
+
+	// Timestamp is the event time as duration since an arbitrary reference.
+	// Useful for calculating velocities in fling gestures.
+	// Zero if timestamps are not available on the platform.
+	Timestamp time.Duration
+}
+
+// TouchEventSource extends EventSource with touch input capabilities.
+// This interface is optional - not all EventSource implementations
+// support touch input (e.g., desktop-only applications).
+//
+// Implementation note: Rather than adding to EventSource directly,
+// we use a separate interface to maintain backward compatibility
+// and allow type assertion:
+//
+//	if tes, ok := eventSource.(gpucontext.TouchEventSource); ok {
+//	    tes.OnTouch(handleTouchEvent)
+//	}
+type TouchEventSource interface {
+	// OnTouch registers a callback for touch events.
+	// The callback receives a TouchEvent containing all touch information.
+	//
+	// Callback threading: Called on the main/UI thread.
+	// Callbacks should be fast and non-blocking.
+	//
+	// Touch events are delivered in order: Began -> Moved* -> Ended/Cancelled
+	// Multi-touch events for simultaneous contacts are coalesced into single events.
+	OnTouch(fn func(TouchEvent))
+}
+
+// NullTouchEventSource implements TouchEventSource by ignoring all registrations.
+// Useful for platforms or configurations where touch input is not available.
+type NullTouchEventSource struct{}
+
+// OnTouch does nothing.
+func (NullTouchEventSource) OnTouch(func(TouchEvent)) {}
+
+// Ensure NullTouchEventSource implements TouchEventSource.
+var _ TouchEventSource = NullTouchEventSource{}

--- a/webgpu_types.go
+++ b/webgpu_types.go
@@ -1,5 +1,5 @@
 // Copyright 2026 The gogpu Authors
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-License-Identifier: MIT
 
 package gpucontext
 


### PR DESCRIPTION
## Summary

New interfaces for cross-package integration in gogpu ecosystem.

### Texture Rendering (INT-004)
- `Texture` — minimal interface (Width, Height)
- `TextureDrawer` — draw textures without direct gogpu dependency
- `TextureCreator` — create textures from RGBA pixel data

### Touch Input (INPUT-001)
- `TouchID`, `TouchPhase`, `TouchPoint`, `TouchEvent`
- `TouchEventSource` interface for touch-capable platforms
- `NullTouchEventSource` for desktop-only apps

### Also
- Unified license headers to MIT
- Updated package documentation

## Research

Touch interface design based on analysis of:
- W3C Touch/Pointer Events
- Android MotionEvent
- iOS UITouch
- SDL2, Flutter, Gio, Ebitengine

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run` — 0 issues
- [x] Documentation updated

Closes #1 (Touch Input Support - interface only, implementation later)