### PR TITLE
feat: add TextureUpdater interface for dynamic texture updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-02-05
+
+### Added
+
+- **TextureUpdater interface** for updating existing texture pixel data ([gg#79](https://github.com/gogpu/gg/issues/79))
+  - `UpdateData(data []byte) error` — upload new pixel data to existing texture
+  - Enables proper error handling for dynamic content (canvas rendering, video frames)
+  - Implemented by `gogpu.Texture`
+
+## [0.6.0] - 2026-01-31
+
+### Added
+
+- **Gesture Events** for multi-touch gesture recognition ([#6](https://github.com/gogpu/gpucontext/pull/6))
+  - `GestureEvent` — Vello-style per-frame gesture deltas (zoom, rotation, translation)
+  - `GestureEventSource` — interface for registering gesture callbacks
+  - `NullGestureEventSource` — no-op implementation
+
 ## [0.5.0] - 2026-01-31
 
 ### Added
@@ -33,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TouchCancelled → TouchCanceled** — US English spelling (misspell linter)
 - Removed unused `DeviceHandle` alias
 
+[0.7.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.7.0
+[0.6.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.6.0
 [0.5.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.5.0
 
 ## [0.4.0] - 2026-01-30

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go get github.com/gogpu/gpucontext
 - **PointerEventSource** — W3C Pointer Events Level 3 (unified mouse/touch/pen)
 - **ScrollEventSource** — Scroll/wheel events with pixel/line/page modes
 - **TouchEventSource** — Interface for multi-touch input (mobile, tablets, touchscreens)
-- **Texture** — Minimal interface for GPU textures with TextureDrawer/TextureCreator
+- **Texture** — Minimal interface for GPU textures with TextureUpdater/TextureDrawer/TextureCreator
 - **IME Support** — Input Method Editor for CJK languages (Chinese, Japanese, Korean)
 - **Registry[T]** — Generic registry with priority-based backend selection
 - **WebGPU Interfaces** — Device, Queue, Adapter, Surface interfaces
@@ -140,6 +140,17 @@ type TextureDrawer interface {
 // TextureCreator can create textures from pixel data
 type TextureCreator interface {
     CreateTexture(width, height int, pixels []byte) (Texture, error)
+}
+```
+
+### TextureUpdater (Dynamic Content)
+
+`TextureUpdater` enables efficient texture updates without recreating textures:
+
+```go
+// TextureUpdater updates existing texture pixel data
+type TextureUpdater interface {
+    UpdateData(data []byte) error
 }
 ```
 

--- a/texture.go
+++ b/texture.go
@@ -22,6 +22,19 @@ type Texture interface {
 	Height() int
 }
 
+// TextureUpdater updates existing texture pixel data.
+// Use for dynamic content such as canvas rendering and video frames.
+//
+// Implementations:
+//   - gogpu.Texture implements TextureUpdater
+type TextureUpdater interface {
+	// UpdateData uploads new pixel data to the texture.
+	// Data must be exactly width * height * bytesPerPixel bytes (typically RGBA).
+	//
+	// Returns error if the texture has been destroyed or data size is invalid.
+	UpdateData(data []byte) error
+}
+
 // TextureDrawer provides texture drawing capabilities for 2D rendering.
 // This interface enables packages like ggcanvas to draw textures without
 // depending directly on gogpu, following the Dependency Inversion Principle.


### PR DESCRIPTION
## Summary

- Add `TextureUpdater` interface with `UpdateData(data []byte) error` signature
- Enables proper error handling for dynamic texture content (canvas rendering, video frames)
- Resolves [gg#79](https://github.com/gogpu/gg/issues/79) — ggcanvas texture updates silently failing due to interface mismatch
- Update CHANGELOG (v0.7.0 + missing v0.6.0 entry) and README

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] CI validates cross-platform (Linux, macOS, Windows)
