### PR TITLE
feat: add HalProvider interface for GPU device sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-10
+
+### Added
+
+- **HalProvider interface** for direct HAL device/queue access ([gg#95](https://github.com/gogpu/gg/issues/95))
+  - `HalDevice() any` — returns underlying HAL device for direct GPU access
+  - `HalQueue() any` — returns underlying HAL queue for direct GPU access
+  - Optional interface — use type assertion on DeviceProvider:
+    `if hp, ok := provider.(gpucontext.HalProvider); ok { ... }`
+  - Enables GPU accelerators (e.g., gg SDF pipeline) to share devices with host applications
+    without creating their own wgpu instance
+
 ## [0.8.0] - 2026-02-06
 
 ### Added
@@ -93,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TouchCancelled → TouchCanceled** — US English spelling (misspell linter)
 - Removed unused `DeviceHandle` alias
 
+[0.9.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.9.0
 [0.8.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.8.0
 [0.7.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.7.0
 [0.6.0]: https://github.com/gogpu/gpucontext/releases/tag/v0.6.0

--- a/hal_provider.go
+++ b/hal_provider.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gpucontext
+
+// HalProvider is an optional interface for DeviceProviders that can expose
+// low-level HAL types directly. This enables GPU accelerators to share
+// devices without creating their own.
+//
+// The returned any values are hal.Device and hal.Queue from wgpu/hal.
+// Consumers type-assert to the concrete hal types they need.
+//
+// Example usage:
+//
+//	if hp, ok := provider.(gpucontext.HalProvider); ok {
+//	    device := hp.HalDevice().(hal.Device)
+//	    queue := hp.HalQueue().(hal.Queue)
+//	}
+type HalProvider interface {
+	// HalDevice returns the underlying HAL device for direct GPU access.
+	// Returns nil if HAL access is not available.
+	HalDevice() any
+
+	// HalQueue returns the underlying HAL queue for direct GPU access.
+	// Returns nil if HAL access is not available.
+	HalQueue() any
+}


### PR DESCRIPTION
## Summary

- Add `HalProvider` interface for direct HAL device/queue access
- Enables GPU accelerators (e.g., gg SDF pipeline) to share the host device without creating their own wgpu instance
- Optional interface — consumers use type assertion on `DeviceProvider`
- Update CHANGELOG.md and README.md for v0.9.0