### PR TITLE
docs: update WindowProvider to logical points (DIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **WindowProvider.Size()** now documented as returning logical points (DIP) instead of physical pixels
+  - Aligns with gogpu RETINA refactor: `App.Size()` returns logical coordinates
+  - Physical pixel dimensions = `Size() * ScaleFactor()`
+  - `NullWindowProvider` fields W/H updated to logical points
+  - README examples updated for HiDPI-aware rendering pattern
+
 ## [0.9.0] - 2026-02-10
 
 ### Added
@@ -22,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **WindowProvider interface** for window geometry and DPI integration
-  - `Size() (width, height int)` — window client area in physical pixels
+  - `Size() (width, height int)` — window client area in logical points (DIP)
   - `ScaleFactor() float64` — DPI scale factor (1.0 = standard, 2.0 = Retina/HiDPI)
   - `RequestRedraw()` — request a new frame in on-demand rendering mode
   - `NullWindowProvider` — configurable defaults for testing and headless operation

--- a/README.md
+++ b/README.md
@@ -86,18 +86,26 @@ func (app *App) HalDevice() any { return app.halDevice }
 func (app *App) HalQueue() any  { return app.halQueue }
 ```
 
-### WindowProvider (for UI frameworks)
+### WindowProvider (for UI frameworks and rendering libraries)
 
-The `WindowProvider` interface enables UI frameworks to query window dimensions and DPI:
+The `WindowProvider` interface enables UI frameworks and rendering libraries to query
+window dimensions (logical points) and DPI scale factor:
 
 ```go
 // In gogpu/ui - uses WindowProvider for layout
 func (ui *UI) Layout(wp gpucontext.WindowProvider) {
-    w, h := wp.Size()
-    scale := wp.ScaleFactor()
-    dpW := float64(w) / scale
-    dpH := float64(h) / scale
-    ui.root.Layout(dpW, dpH)
+    w, h := wp.Size()           // logical points (DIP)
+    scale := wp.ScaleFactor()   // 2.0 on Retina
+    ui.root.Layout(w, h, scale)
+}
+
+// In gg/ggcanvas - auto-detects HiDPI from provider
+func New(provider gpucontext.DeviceProvider, w, h int) (*Canvas, error) {
+    scale := 1.0
+    if wp, ok := provider.(gpucontext.WindowProvider); ok {
+        scale = wp.ScaleFactor()
+    }
+    // allocate pixmap at physical resolution: w*scale x h*scale
 }
 ```
 

--- a/window.go
+++ b/window.go
@@ -5,33 +5,34 @@ package gpucontext
 
 // WindowProvider provides window geometry and DPI information.
 //
-// This interface enables UI frameworks (like gogpu/ui) to query window
-// dimensions and scale factor for layout calculations in density-independent
-// pixels (Dp), and to request redraws for on-demand rendering.
+// This interface enables UI frameworks (like gogpu/ui) and rendering
+// libraries (like gg/ggcanvas) to query window dimensions and scale factor
+// for HiDPI-aware layout and rendering.
+//
+// Size() returns logical points (DIP — density-independent pixels).
+// To get physical pixel dimensions, multiply by ScaleFactor():
+//
+//	physW := int(float64(w) * scale)
 //
 // Implementations:
 //   - gogpu.App implements WindowProvider via platform window
+//   - gogpu.gpuContextAdapter implements WindowProvider (returned by GPUContextProvider)
 //   - NullWindowProvider provides configurable defaults for testing
 //
-// Example usage in a UI framework:
+// Example usage:
 //
 //	func (ui *UI) Layout(wp gpucontext.WindowProvider) {
-//	    w, h := wp.Size()
-//	    scale := wp.ScaleFactor()
-//	    dpW := float64(w) / scale
-//	    dpH := float64(h) / scale
-//	    ui.root.Layout(dpW, dpH)
+//	    w, h := wp.Size()           // logical points
+//	    scale := wp.ScaleFactor()   // 2.0 on Retina
+//	    ui.root.Layout(w, h, scale)
 //	}
-//
-// Note: This interface is designed for gogpu <-> ui integration.
-// The rendering library (gg) does NOT use this interface.
 type WindowProvider interface {
-	// Size returns the current window client area dimensions in physical pixels.
+	// Size returns the current window client area dimensions in logical points (DIP).
+	// On HiDPI displays, multiply by ScaleFactor() to get physical pixel dimensions.
 	Size() (width, height int)
 
 	// ScaleFactor returns the DPI scale factor.
 	// 1.0 = standard (96 DPI on Windows, 72 on macOS), 2.0 = Retina/HiDPI.
-	// Used to convert between physical pixels and density-independent pixels (Dp).
 	ScaleFactor() float64
 
 	// RequestRedraw requests the host to render a new frame.
@@ -48,13 +49,13 @@ type WindowProvider interface {
 // Example:
 //
 //	wp := gpucontext.NullWindowProvider{W: 800, H: 600, SF: 2.0}
-//	w, h := wp.Size()       // 800, 600
+//	w, h := wp.Size()       // 800, 600 (logical points)
 //	scale := wp.ScaleFactor() // 2.0
 type NullWindowProvider struct {
-	// W is the window width in physical pixels.
+	// W is the window width in logical points (DIP).
 	W int
 
-	// H is the window height in physical pixels.
+	// H is the window height in logical points (DIP).
 	H int
 
 	// SF is the DPI scale factor. When zero, ScaleFactor returns 1.0.


### PR DESCRIPTION
## Summary

- Update `WindowProvider.Size()` documentation: "physical pixels" -> "logical points (DIP)"
- Update `NullWindowProvider` field comments (W, H) to logical points
- Update README example with HiDPI-aware ggcanvas integration pattern
- Add Unreleased section to CHANGELOG

## Context

After the gogpu RETINA-001 refactor, `App.Size()` returns logical points (DIP) instead of physical pixels. The `WindowProvider` interface documentation was out of date. This PR aligns the interface contract with actual behavior.

No code changes — only comments, docs, and CHANGELOG.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
