### PR TITLE
feat: CursorMode + PointerEvent DeltaX/DeltaY (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-09
+
+### Added
+
+- **CursorMode** — `CursorNormal`, `CursorLocked`, `CursorConfined` constants for mouse grab / pointer lock.
+  Matches SDL `SDL_SetRelativeMouseMode` and `SDL_SetWindowMouseGrab` semantics. (gogpu#173)
+- **PointerEvent.DeltaX/DeltaY** — relative mouse movement fields for locked cursor mode.
+  Non-zero only when cursor is locked (FPS mouselook). Follows W3C Pointer Events pattern.
+
 ## [0.11.0] - 2026-03-20
 
 ### Added

--- a/platform.go
+++ b/platform.go
@@ -135,6 +135,42 @@ func (c CursorShape) String() string {
 	}
 }
 
+// CursorMode controls how the mouse cursor behaves within the window.
+//
+// This follows the pattern established by SDL_SetRelativeMouseMode and
+// SDL_SetWindowMouseGrab, providing three modes that cover the common
+// use cases for games and interactive applications.
+type CursorMode int
+
+const (
+	// CursorModeNormal is the default mode: cursor is visible and moves freely.
+	CursorModeNormal CursorMode = iota
+
+	// CursorModeLocked hides the cursor and confines it to the window.
+	// Mouse movement is reported as relative deltas (DeltaX/DeltaY on PointerEvent).
+	// The cursor is warped to the window center on each frame.
+	// Equivalent to SDL_SetRelativeMouseMode(SDL_TRUE).
+	CursorModeLocked
+
+	// CursorModeConfined keeps the cursor visible but confines it to the window bounds.
+	// Equivalent to SDL_SetWindowMouseGrab(SDL_TRUE).
+	CursorModeConfined
+)
+
+// String returns the cursor mode name for debugging.
+func (m CursorMode) String() string {
+	switch m {
+	case CursorModeNormal:
+		return "Normal"
+	case CursorModeLocked:
+		return "Locked"
+	case CursorModeConfined:
+		return "Confined"
+	default:
+		return "Unknown"
+	}
+}
+
 // NullPlatformProvider implements PlatformProvider with no-op behavior.
 // Used for testing and platforms without OS integration.
 //

--- a/pointer.go
+++ b/pointer.go
@@ -105,6 +105,15 @@ type PointerEvent struct {
 	// Modifiers contains the keyboard modifier state at event time.
 	Modifiers Modifiers
 
+	// DeltaX is the relative horizontal movement in logical pixels.
+	// Non-zero only when CursorModeLocked is active; zero otherwise.
+	// Use for first-person camera, drag, and other relative-motion input.
+	DeltaX float64
+
+	// DeltaY is the relative vertical movement in logical pixels.
+	// Non-zero only when CursorModeLocked is active; zero otherwise.
+	DeltaY float64
+
 	// Timestamp is the event time as duration since an arbitrary reference.
 	// Useful for calculating velocities and detecting double-clicks.
 	// Zero if timestamps are not available on the platform.


### PR DESCRIPTION
## Summary

- CursorModeNormal, CursorModeLocked, CursorModeConfined — SDL parity for mouse grab / pointer lock
- PointerEvent.DeltaX/DeltaY — relative mouse movement in locked mode

Needed for gogpu#173 (@darkliquid ironwail-go Quake engine).

## Test plan
- [x] Build passes
- [x] Lint 0 issues