### PR TITLE
feat: WindowChrome.SetFullscreen + IsFullscreen (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-04-30
+
+### Added
+
+- **WindowChrome.SetFullscreen / IsFullscreen** — runtime fullscreen toggle interface (ADR-018). Enables `App.SetFullscreen(bool)` in gogpu for borderless fullscreen (Windows), native `toggleFullScreen:` (macOS), `_NET_WM_STATE_FULLSCREEN` (X11), `xdg_toplevel.set_fullscreen` (Wayland). NullWindowChrome provides no-op defaults. Triggered by ui#88 (@AgentNemo00).
+
 ## [0.15.0] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ go get github.com/gogpu/gpucontext
 - **ScrollEventSource** — Scroll/wheel events with pixel/line/page modes
 - **Texture** — Minimal interface for GPU textures with TextureUpdater/TextureRegionUpdater/TextureDrawer/TextureCreator
 - **IME Support** — Input Method Editor for CJK languages (Chinese, Japanese, Korean)
-- **WindowChrome** — Custom window chrome for frameless windows (hit testing, minimize/maximize/close)
+- **WindowChrome** — Custom window chrome for frameless windows (hit testing, minimize/maximize/close) + runtime fullscreen toggle
 - **Registry[T]** — Generic registry with priority-based backend selection
 - **WebGPU Interfaces** — Device, Queue, Adapter, Surface interfaces
 - **WebGPU Types** — Re-exports from [gputypes](https://github.com/gogpu/gputypes) (TextureFormat, etc.)
@@ -255,9 +255,9 @@ func (ctx *Context) DrawTexture(tex gpucontext.Texture, x, y float32) error {
 }
 ```
 
-### WindowChrome (frameless windows)
+### WindowChrome (frameless windows + fullscreen)
 
-`WindowChrome` enables custom window chrome for frameless windows with custom title bars:
+`WindowChrome` enables custom window chrome for frameless windows and runtime fullscreen toggle:
 
 ```go
 // In gogpu/ui - custom title bar with hit testing
@@ -277,6 +277,8 @@ func (ui *UI) SetupFramelessWindow(provider gpucontext.WindowProvider) {
 wc.Minimize()
 wc.Maximize()       // toggles maximized/restored
 wc.IsMaximized()    // for button icon state
+wc.SetFullscreen(true)  // enter fullscreen (borderless on Win, native on macOS)
+wc.IsFullscreen()       // query fullscreen state
 wc.Close()
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,9 @@
 
 `gpucontext` is the shared foundation for the [gogpu](https://github.com/gogpu) ecosystem, providing interfaces and utilities for GPU resource sharing without circular dependencies.
 
-## Current: v0.14.0
+## Current: v0.16.0
 
+- WindowChrome.SetFullscreen / IsFullscreen (ADR-018, runtime fullscreen toggle)
 - CursorMode (Locked/Confined/Normal) for mouse grab / pointer lock
 - PointerEvent.DeltaX/DeltaY for relative mouse movement
 - WindowChrome interface for frameless window support

--- a/window_chrome.go
+++ b/window_chrome.go
@@ -145,6 +145,16 @@ type WindowChrome interface {
 	// IsMaximized returns true if the window is currently maximized.
 	IsMaximized() bool
 
+	// SetFullscreen enters or exits fullscreen mode.
+	// On Windows: borderless fullscreen (Chromium pattern).
+	// On macOS: native toggleFullScreen with animation.
+	// On X11: _NET_WM_STATE_FULLSCREEN.
+	// On Wayland: xdg_toplevel.set_fullscreen / unset_fullscreen.
+	SetFullscreen(fullscreen bool)
+
+	// IsFullscreen returns true if the window is currently in fullscreen mode.
+	IsFullscreen() bool
+
 	// Close requests the window to close.
 	// This triggers the normal close flow (close events, cleanup).
 	Close()
@@ -156,6 +166,7 @@ type WindowChrome interface {
 // Default return values:
 //   - IsFrameless: false
 //   - IsMaximized: false
+//   - IsFullscreen: false
 //   - All actions: no-op
 type NullWindowChrome struct{}
 
@@ -176,6 +187,12 @@ func (NullWindowChrome) Maximize() {}
 
 // IsMaximized returns false.
 func (NullWindowChrome) IsMaximized() bool { return false }
+
+// SetFullscreen does nothing.
+func (NullWindowChrome) SetFullscreen(bool) {}
+
+// IsFullscreen returns false.
+func (NullWindowChrome) IsFullscreen() bool { return false }
 
 // Close does nothing.
 func (NullWindowChrome) Close() {}

--- a/window_chrome_test.go
+++ b/window_chrome_test.go
@@ -14,6 +14,9 @@ func TestNullWindowChrome_Defaults(t *testing.T) {
 	if wc.IsMaximized() {
 		t.Error("IsMaximized() should return false")
 	}
+	if wc.IsFullscreen() {
+		t.Error("IsFullscreen() should return false")
+	}
 }
 
 func TestNullWindowChrome_Actions(t *testing.T) {
@@ -26,6 +29,8 @@ func TestNullWindowChrome_Actions(t *testing.T) {
 	wc.SetHitTestCallback(nil)
 	wc.Minimize()
 	wc.Maximize()
+	wc.SetFullscreen(true)
+	wc.SetFullscreen(false)
 	wc.Close()
 }
 
@@ -104,11 +109,12 @@ func TestHitTestResult_Values(t *testing.T) {
 
 // mockWindowChrome verifies the interface can be implemented by custom types.
 type mockWindowChrome struct {
-	frameless bool
-	maximized bool
-	closed    bool
-	minimized bool
-	callback  HitTestCallback
+	frameless  bool
+	maximized  bool
+	fullscreen bool
+	closed     bool
+	minimized  bool
+	callback   HitTestCallback
 }
 
 func (m *mockWindowChrome) SetFrameless(frameless bool)           { m.frameless = frameless }
@@ -117,6 +123,8 @@ func (m *mockWindowChrome) SetHitTestCallback(cb HitTestCallback) { m.callback =
 func (m *mockWindowChrome) Minimize()                             { m.minimized = true }
 func (m *mockWindowChrome) Maximize()                             { m.maximized = !m.maximized }
 func (m *mockWindowChrome) IsMaximized() bool                     { return m.maximized }
+func (m *mockWindowChrome) SetFullscreen(fullscreen bool)         { m.fullscreen = fullscreen }
+func (m *mockWindowChrome) IsFullscreen() bool                    { return m.fullscreen }
 func (m *mockWindowChrome) Close()                                { m.closed = true }
 
 // Ensure mockWindowChrome implements WindowChrome.
@@ -174,6 +182,16 @@ func TestWindowChrome_CustomImplementation(t *testing.T) {
 	wc.Maximize()
 	if wc.IsMaximized() {
 		t.Error("IsMaximized() should return false after second Maximize()")
+	}
+
+	// Test fullscreen
+	wc.SetFullscreen(true)
+	if !wc.IsFullscreen() {
+		t.Error("IsFullscreen() should return true after SetFullscreen(true)")
+	}
+	wc.SetFullscreen(false)
+	if wc.IsFullscreen() {
+		t.Error("IsFullscreen() should return false after SetFullscreen(false)")
 	}
 
 	// Test close


### PR DESCRIPTION
## Summary

- **WindowChrome.SetFullscreen(bool)** — runtime fullscreen toggle interface (ADR-018)
- **WindowChrome.IsFullscreen() bool** — fullscreen state query
- **NullWindowChrome** — no-op defaults added
- Tests: NullWindowChrome defaults, actions, mock with fullscreen toggle

Enables `App.SetFullscreen(bool)` in gogpu for:
- Windows: borderless fullscreen (Chromium pattern)
- macOS: native `toggleFullScreen:` with animation
- X11: `_NET_WM_STATE_FULLSCREEN`
- Wayland: `xdg_toplevel.set_fullscreen`

## Test plan
- [x] All existing tests pass
- [x] New fullscreen tests pass (NullWindowChrome + mock)
- [x] `go fmt` clean
- [x] `golangci-lint` 0 issues