### PR TITLE
feat: AdapterInfo on DeviceProvider (ADR-020, v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-06
+
+### Added
+
+- **AdapterInfo on DeviceProvider** (ADR-020) — `AdapterInfo()` method returns `AdapterInfo{Name, Type}` with `AdapterType` enum (Discrete, Integrated, Software, Unknown). Enables gg render mode auto-selection: CPU rasterizer on software adapters (60 FPS) vs GPU accelerator on real hardware. Triggered by software backend 92x regression after SPIR-V interpreter (FEAT-SW-004).
+
 ## [0.16.0] - 2026-04-30
 
 ### Added

--- a/adapter_info.go
+++ b/adapter_info.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gpucontext
+
+// AdapterType describes the physical GPU adapter type.
+// Used by rendering libraries (gg) for render mode auto-selection.
+type AdapterType int
+
+const (
+	// AdapterTypeDiscrete is a dedicated GPU (NVIDIA, AMD discrete).
+	AdapterTypeDiscrete AdapterType = iota
+	// AdapterTypeIntegrated is an integrated GPU (Intel Iris, AMD Vega iGPU).
+	AdapterTypeIntegrated
+	// AdapterTypeSoftware is a CPU-based software renderer (llvmpipe, SwiftShader, gogpu/wgpu software HAL).
+	AdapterTypeSoftware
+	// AdapterTypeUnknown means the adapter type could not be determined.
+	AdapterTypeUnknown
+)
+
+// String returns the adapter type name.
+func (t AdapterType) String() string {
+	switch t {
+	case AdapterTypeDiscrete:
+		return "Discrete"
+	case AdapterTypeIntegrated:
+		return "Integrated"
+	case AdapterTypeSoftware:
+		return "Software"
+	default:
+		return "Unknown"
+	}
+}
+
+// AdapterInfo describes the physical GPU adapter.
+// Provided by DeviceProvider for render mode decisions.
+type AdapterInfo struct {
+	// Name is the adapter name (e.g., "NVIDIA GeForce RTX 4090", "Software Renderer").
+	Name string
+	// Type is the adapter type (Discrete, Integrated, Software, Unknown).
+	Type AdapterType
+}

--- a/adapter_info_test.go
+++ b/adapter_info_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The gogpu Authors
+// SPDX-License-Identifier: MIT
+
+package gpucontext
+
+import "testing"
+
+func TestAdapterTypeString(t *testing.T) {
+	tests := []struct {
+		typ  AdapterType
+		want string
+	}{
+		{AdapterTypeDiscrete, "Discrete"},
+		{AdapterTypeIntegrated, "Integrated"},
+		{AdapterTypeSoftware, "Software"},
+		{AdapterTypeUnknown, "Unknown"},
+		{AdapterType(99), "Unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.typ.String(); got != tt.want {
+			t.Errorf("AdapterType(%d).String() = %q, want %q", tt.typ, got, tt.want)
+		}
+	}
+}
+
+func TestAdapterInfoZeroValue(t *testing.T) {
+	var info AdapterInfo
+	if info.Name != "" {
+		t.Errorf("zero AdapterInfo.Name = %q, want empty", info.Name)
+	}
+	if info.Type != AdapterTypeDiscrete {
+		t.Errorf("zero AdapterInfo.Type = %d, want %d (Discrete)", info.Type, AdapterTypeDiscrete)
+	}
+}

--- a/device_provider.go
+++ b/device_provider.go
@@ -46,4 +46,10 @@ type DeviceProvider interface {
 	// The adapter provides information about the GPU capabilities.
 	// Some implementations may not expose the adapter.
 	Adapter() Adapter
+
+	// AdapterInfo returns GPU adapter metadata (name, type).
+	// Used by gg for render mode auto-selection: software adapters
+	// prefer CPU rasterizer over GPU shader interpreter.
+	// Returns AdapterTypeUnknown if adapter info is not available.
+	AdapterInfo() AdapterInfo
 }

--- a/doc.go
+++ b/doc.go
@@ -46,3 +46,5 @@
 //
 // Reference: https://github.com/gogpu/gpucontext
 package gpucontext
+
+const stringNone = "None"

--- a/gesture.go
+++ b/gesture.go
@@ -88,7 +88,7 @@ const (
 func (p PinchType) String() string {
 	switch p {
 	case PinchNone:
-		return "None"
+		return stringNone
 	case PinchHorizontal:
 		return "Horizontal"
 	case PinchVertical:

--- a/platform.go
+++ b/platform.go
@@ -129,7 +129,7 @@ func (c CursorShape) String() string {
 	case CursorWait:
 		return "Wait"
 	case CursorNone:
-		return "None"
+		return stringNone
 	default:
 		return "Unknown"
 	}

--- a/pointer.go
+++ b/pointer.go
@@ -240,7 +240,7 @@ const (
 func (b Button) String() string {
 	switch b {
 	case ButtonNone:
-		return "None"
+		return stringNone
 	case ButtonLeft:
 		return "Left"
 	case ButtonMiddle:


### PR DESCRIPTION
## Summary

- **AdapterInfo** — new `AdapterInfo()` method on `DeviceProvider` returning `AdapterInfo{Name, Type}`
- **AdapterType** enum — Discrete, Integrated, Software, Unknown
- Enables gg render mode auto-selection: CPU rasterizer on software adapters vs GPU accelerator on real hardware

## Context

After SPIR-V interpreter (FEAT-SW-004), gg's GPU accelerator intercepted rendering on software backend, routing 2D operations through the interpreter at 0.65 FPS instead of the optimized CPU rasterizer at 60 FPS. With AdapterInfo, gg can detect software adapter and prefer its CPU path. See ADR-020.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [ ] CI green