### PR TITLE
docs: logical DIP coordinate space contract

### DIFF
--- a/events.go
+++ b/events.go
@@ -44,14 +44,21 @@ type EventSource interface {
 	OnTextInput(func(text string))
 
 	// Mouse events
+	//
+	// All mouse/pointer coordinates (x, y) are in logical DIP (device-independent
+	// pixels), consistent with WindowProvider.Size(). Do NOT divide by ScaleFactor —
+	// the framework applies DPI scaling internally on all platforms.
 
 	// OnMouseMove registers a callback for mouse movement.
+	// x, y are in logical DIP relative to the window content area.
 	OnMouseMove(func(x, y float64))
 
 	// OnMousePress registers a callback for mouse button press.
+	// x, y are in logical DIP relative to the window content area.
 	OnMousePress(func(button MouseButton, x, y float64))
 
 	// OnMouseRelease registers a callback for mouse button release.
+	// x, y are in logical DIP relative to the window content area.
 	OnMouseRelease(func(button MouseButton, x, y float64))
 
 	// OnScroll registers a callback for scroll wheel events.

--- a/pointer.go
+++ b/pointer.go
@@ -42,12 +42,16 @@ type PointerEvent struct {
 	// The ID remains constant from PointerDown through PointerUp/PointerCancel.
 	PointerID int
 
-	// X is the horizontal position relative to the window content area.
-	// Uses logical pixels (CSS pixels equivalent).
+	// X is the horizontal position relative to the window content area, in
+	// logical DIP (device-independent pixels). Consistent with App.Size() on
+	// all platforms. Do NOT divide by ScaleFactor — DPI scaling is applied
+	// internally by the framework.
 	X float64
 
-	// Y is the vertical position relative to the window content area.
-	// Uses logical pixels (CSS pixels equivalent).
+	// Y is the vertical position relative to the window content area, in
+	// logical DIP (device-independent pixels). Consistent with App.Size() on
+	// all platforms. Do NOT divide by ScaleFactor — DPI scaling is applied
+	// internally by the framework.
 	Y float64
 
 	// Pressure indicates the normalized pressure of the pointer input.

--- a/scroll.go
+++ b/scroll.go
@@ -68,12 +68,12 @@ func (p ScrollPhase) String() string {
 //	    }
 //	})
 type ScrollEvent struct {
-	// X is the pointer horizontal position at the time of scrolling.
-	// Uses logical pixels relative to the window content area.
+	// X is the pointer horizontal position at the time of scrolling, in
+	// logical DIP (device-independent pixels). Consistent with App.Size().
 	X float64
 
-	// Y is the pointer vertical position at the time of scrolling.
-	// Uses logical pixels relative to the window content area.
+	// Y is the pointer vertical position at the time of scrolling, in
+	// logical DIP (device-independent pixels). Consistent with App.Size().
 	Y float64
 
 	// DeltaX is the horizontal scroll amount.


### PR DESCRIPTION
## Summary

Documents that all mouse/pointer/scroll coordinates in the `EventSource` and `PointerEvent`/`ScrollEvent` types are in **logical DIP** (device-independent pixels), consistent with `WindowProvider.Size()`.

Explicitly states: **do NOT divide by `ScaleFactor()`** — DPI scaling is applied internally by the framework on all platforms.

## Motivation

gogpu#398: @unxed's f4 file manager divided mouse coordinates by `ScaleFactor()`, causing double-scaling on Windows HiDPI (125%/150%). The existing godoc said "Uses logical pixels (CSS pixels equivalent)" which was technically correct but did not explicitly warn against manual scaling.

## Changes

- `events.go` — block comment above mouse event methods + per-method "x, y are in logical DIP"
- `pointer.go` — `PointerEvent.X/Y` godoc: explicit "Do NOT divide by ScaleFactor"
- `scroll.go` — `ScrollEvent.X/Y` godoc: "logical DIP, consistent with App.Size()"

Documentation only — zero code changes.

## Test plan

- [x] `go build ./...`
- [x] No code changes to test
- [ ] CI